### PR TITLE
Add package existence check

### DIFF
--- a/src/get-applicable-codemods.js
+++ b/src/get-applicable-codemods.js
@@ -20,7 +20,7 @@ module.exports = async function getApplicableCodemods({
   let resolvedVersions = await pReduce(Object.keys(codemods), async(resolvedVersions, codemod) => {
     return await pReduce(Object.keys(codemods[codemod].versions), async(resolvedVersions, packageName) => {
       let packageRange = versionRanges[packageName];
-      if (versionRanges.hasOwnProperty(packageName) && !resolvedVersions[packageName]) {
+      if (Object.prototype.hasOwnProperty.call(versionRanges, packageName) && !resolvedVersions[packageName]) {
         // eslint-disable-next-line require-atomic-updates
         resolvedVersions[packageName] = await resolveVersionRange(packageName, packageRange);
       }
@@ -30,7 +30,7 @@ module.exports = async function getApplicableCodemods({
 
   return Object.entries(codemods).filter(([, codemod]) => {
     let keys = Object.keys(codemod.versions);
-    let areVersionsInRange = keys.every(key => resolvedVersions.hasOwnProperty(key) && semver.gte(resolvedVersions[key], codemod.versions[key]));
+    let areVersionsInRange = keys.every(key => Object.prototype.hasOwnProperty.call(resolvedVersions, key) && semver.gte(resolvedVersions[key], codemod.versions[key]));
     let hasCorrectProjectOption = projectOptions.some(option => codemod.projectOptions.includes(option));
     let isNodeVersionInRange = semver.gte(nodeVersion, codemod.nodeVersion);
     return areVersionsInRange && hasCorrectProjectOption && isNodeVersionInRange;

--- a/src/get-applicable-codemods.js
+++ b/src/get-applicable-codemods.js
@@ -20,7 +20,7 @@ module.exports = async function getApplicableCodemods({
   let resolvedVersions = await pReduce(Object.keys(codemods), async(resolvedVersions, codemod) => {
     return await pReduce(Object.keys(codemods[codemod].versions), async(resolvedVersions, packageName) => {
       let packageRange = versionRanges[packageName];
-      if (packageRange && !resolvedVersions[packageName]) {
+      if (versionRanges.hasOwnProperty(packageName) && !resolvedVersions[packageName]) {
         // eslint-disable-next-line require-atomic-updates
         resolvedVersions[packageName] = await resolveVersionRange(packageName, packageRange);
       }
@@ -30,7 +30,7 @@ module.exports = async function getApplicableCodemods({
 
   return Object.entries(codemods).filter(([, codemod]) => {
     let keys = Object.keys(codemod.versions);
-    let areVersionsInRange = keys.every(key => resolvedVersions[key] && semver.gte(resolvedVersions[key], codemod.versions[key]));
+    let areVersionsInRange = keys.every(key => resolvedVersions.hasOwnProperty(key) && semver.gte(resolvedVersions[key], codemod.versions[key]));
     let hasCorrectProjectOption = projectOptions.some(option => codemod.projectOptions.includes(option));
     let isNodeVersionInRange = semver.gte(nodeVersion, codemod.nodeVersion);
     return areVersionsInRange && hasCorrectProjectOption && isNodeVersionInRange;

--- a/src/get-applicable-codemods.js
+++ b/src/get-applicable-codemods.js
@@ -30,7 +30,7 @@ module.exports = async function getApplicableCodemods({
 
   return Object.entries(codemods).filter(([, codemod]) => {
     let keys = Object.keys(codemod.versions);
-    let areVersionsInRange = keys.every(key => semver.gte(resolvedVersions[key], codemod.versions[key]));
+    let areVersionsInRange = keys.every(key => resolvedVersions[key] && semver.gte(resolvedVersions[key], codemod.versions[key]));
     let hasCorrectProjectOption = projectOptions.some(option => codemod.projectOptions.includes(option));
     let isNodeVersionInRange = semver.gte(nodeVersion, codemod.nodeVersion);
     return areVersionsInRange && hasCorrectProjectOption && isNodeVersionInRange;

--- a/test/unit/get-applicable-codemods-test.js
+++ b/test/unit/get-applicable-codemods-test.js
@@ -162,4 +162,31 @@ describe(getApplicableCodemods, function() {
 
     expect(codemods).to.deep.equal({});
   });
+
+  it('uses minimal applicable version for empty constraint', async function() {
+    const actualCodeMods = {
+      testCodemod: {
+        versions: {
+          'test-dependency': '0.0.1'
+        },
+        projectOptions: ['testProjectOption'],
+        nodeVersion: '4.0.0'
+      }
+    };
+
+    getCodemods.resolves(actualCodeMods);
+
+    getNodeVersion.returns('4.0.0');
+
+    let codemods = await getApplicableCodemods({
+      projectOptions: ['testProjectOption'],
+      packageJson: {
+        dependencies: {
+          'test-dependency': ''
+        }
+      }
+    });
+
+    expect(codemods).to.deep.equal(actualCodeMods);
+  });
 });

--- a/test/unit/get-applicable-codemods-test.js
+++ b/test/unit/get-applicable-codemods-test.js
@@ -137,4 +137,29 @@ describe(getApplicableCodemods, function() {
 
     expect(codemods).to.deep.equal({});
   });
+
+  it('excludes codemod with unsatisfied dependency', async function() {
+    getCodemods.resolves({
+      testCodemod: {
+        versions: {
+          'test-dependency': '0.0.2'
+        },
+        projectOptions: ['testProjectOption'],
+        nodeVersion: '4.0.0'
+      }
+    });
+
+    getNodeVersion.returns('4.0.0');
+
+    let codemods = await getApplicableCodemods({
+      projectOptions: ['testProjectOption'],
+      packageJson: {
+        dependencies: {
+          'just-another-dependency': '^0.0.1'
+        }
+      }
+    });
+
+    expect(codemods).to.deep.equal({});
+  });
 });

--- a/test/unit/get-applicable-codemods-test.js
+++ b/test/unit/get-applicable-codemods-test.js
@@ -164,7 +164,7 @@ describe(getApplicableCodemods, function() {
   });
 
   it('uses minimal applicable version for empty constraint', async function() {
-    const actualCodeMods = {
+    let actualCodeMods = {
       testCodemod: {
         versions: {
           'test-dependency': '0.0.1'


### PR DESCRIPTION
Currently, if a codemod specifies a version constraint on a project dependency, getting the list of applicable codemods will fail if the destination project does not actually depend on the package the codemod has a constraint on. This patch adds a unit test to demonstrate the issue, and adds an existence check to packages that codemods specify version constraints against to resolve it.