### PR TITLE
Double-quote `exec(` path arguments

### DIFF
--- a/src/get-start-and-end-commands.js
+++ b/src/get-start-and-end-commands.js
@@ -64,7 +64,7 @@ async function _prepareCommand({
     rimraf(path.join(appPath, 'yarn.lock'))
   ]);
 
-  return `node ${cpr} ${appPath} .`;
+  return `node "${cpr}" "${appPath}" .`;
 }
 
 async function tryPrepareCommandUsingCache({

--- a/test/integration/get-start-and-end-commands-test.js
+++ b/test/integration/get-start-and-end-commands-test.js
@@ -179,8 +179,8 @@ describe(_getStartAndEndCommands, function() {
       let commands = await getStartAndEndCommands();
 
       expect(commands).to.deep.equal({
-        startCommand: `node ${cpr} ${startPath} .`,
-        endCommand: `node ${cpr} ${endPath} .`
+        startCommand: `node "${cpr}" "${startPath}" .`,
+        endCommand: `node "${cpr}" "${endPath}" .`
       });
 
       expect(cacheStub1.callCount).to.equal(2);
@@ -227,8 +227,8 @@ describe(_getStartAndEndCommands, function() {
       let commands = await getStartAndEndCommands();
 
       expect(commands).to.deep.equal({
-        startCommand: `node ${cpr} ${startPath} .`,
-        endCommand: `node ${cpr} ${endPath} .`
+        startCommand: `node "${cpr}" "${startPath}" .`,
+        endCommand: `node "${cpr}" "${endPath}" .`
       });
 
       expect(cacheStub1.callCount).to.equal(2);
@@ -302,8 +302,8 @@ describe(_getStartAndEndCommands, function() {
       let commands = await getStartAndEndCommands();
 
       expect(commands).to.deep.equal({
-        startCommand: `node ${cpr} ${startPath} .`,
-        endCommand: `node ${cpr} ${endPath} .`
+        startCommand: `node "${cpr}" "${startPath}" .`,
+        endCommand: `node "${cpr}" "${endPath}" .`
       });
 
       expect(cacheStub1.callCount).to.equal(2);
@@ -343,8 +343,8 @@ describe(_getStartAndEndCommands, function() {
       let commands = await getStartAndEndCommands();
 
       expect(commands).to.deep.equal({
-        startCommand: `node ${cpr} ${startPath} .`,
-        endCommand: `node ${cpr} ${endPath} .`
+        startCommand: `node "${cpr}" "${startPath}" .`,
+        endCommand: `node "${cpr}" "${endPath}" .`
       });
 
       expect(cacheStub1.callCount).to.equal(2);
@@ -387,8 +387,8 @@ describe(_getStartAndEndCommands, function() {
       let commands = await getStartAndEndCommands();
 
       expect(commands).to.deep.equal({
-        startCommand: `node ${cpr} ${startPath} .`,
-        endCommand: `node ${cpr} ${endPath} .`
+        startCommand: `node "${cpr}" "${startPath}" .`,
+        endCommand: `node "${cpr}" "${endPath}" .`
       });
 
       expect(cacheStub1.callCount).to.equal(2);
@@ -494,8 +494,8 @@ describe(_getStartAndEndCommands, function() {
       let commands = await getStartAndEndCommands();
 
       expect(commands).to.deep.equal({
-        startCommand: `node ${cpr} ${startPath} .`,
-        endCommand: `node ${cpr} ${endPath} .`
+        startCommand: `node "${cpr}" "${startPath}" .`,
+        endCommand: `node "${cpr}" "${endPath}" .`
       });
 
       expect(cacheStub1.callCount).to.equal(0);
@@ -568,7 +568,7 @@ describe(_getStartAndEndCommands, function() {
 
     expect(commands).to.deep.equal({
       startCommand: null,
-      endCommand: `node ${cpr} ${endPath} .`
+      endCommand: `node "${cpr}" "${endPath}" .`
     });
 
     expect(cacheStub1.callCount).to.equal(1);
@@ -588,7 +588,7 @@ describe(_getStartAndEndCommands, function() {
 
     expect(commands).to.deep.equal({
       startCommand: null,
-      endCommand: `node ${cpr} ${endPath} .`
+      endCommand: `node "${cpr}" "${endPath}" .`
     });
 
     expect(cacheStub1.callCount).to.equal(1);


### PR DESCRIPTION
It's a recommended approach, in order to avoid `child_process.exec(` to misbehave for paths containing spaces

see: https://nodejs.org/docs/latest-v14.x/api/child_process.html#child_process_child_process_exec_command_options_callback

> Double quotes are used so that the space in the path is not interpreted as a delimiter of multiple arguments.

### Why

recently I've migrated to another machine. For some reason migration assistant created my new profile with a name containing a space in the path, like `/Users/username 1/`.  Now when I do `ember-cli-update`, it results to error like:

```
{ Error: Command failed: node /Users/username 1/.nvm/versions/node/v10.22.0/lib/node_modules/ember-cli-update/node_modules/cpr/bin/cpr /var/folders/d9/kk8qd5p12j7_zmxkffkcslr80000gn/T/tmp-89253KhGHbUo6tCdO/ember-cli-update .
internal/modules/cjs/loader.js:638
    throw err;
    ^

Error: Cannot find module '/Users/username'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)

    at ChildProcess.exithandler (child_process.js:294:12)
    at ChildProcess.emit (events.js:198:13)
    at maybeClose (internal/child_process.js:982:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)
  killed: false,
  code: 1,
  signal: null,
  cmd:
   'node /Users/username 1/.nvm/versions/node/v10.22.0/lib/node_modules/ember-cli-update/node_modules/cpr/bin/cpr /var/folders/d9/kk8qd5p12j7_zmxkffkcslr80000gn/T/tmp-89253KhGHbUo6tCdO/ember-cli-update .',
  stdout: '',
  stderr:
   'internal/modules/cjs/loader.js:638\n    throw err;\n    ^\n\nError: Cannot find module \'/Users/username\'\n    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)\n    at Function.Module._load (internal/modules/cjs/loader.js:562:25)\n    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)\n    at startup (internal/bootstrap/node.js:283:19)\n    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)\n' }
```

It happens cause the `cpr` path is an [absolute](https://github.com/kellyselden/boilerplate-update/blob/master/src/get-start-and-end-commands.js#L8) one. And since it's passed to the [`child_process.exec(`](https://github.com/kellyselden/git-diff-apply/blob/ac1ba33a8a6928add624a40df15acb6c910d5b72/src/create-custom-remote.js#L31), it fails for cases when a path contains spaces.

 ### Testing

I've avoided writing a test case for this. But locally, the test suite fails on my machine, w/o the change. Also my `ember-cli-update` succeeded with the change!

If we need a specific acceptance or integration test here, please let me know, I'll make a deeper look here.