### PR TITLE
remove double debug logging

### DIFF
--- a/src/npx.js
+++ b/src/npx.js
@@ -1,14 +1,9 @@
 'use strict';
 
 const { exec } = require('./run');
-const debug = require('./debug');
 
 function npx(command, options) {
-  let npxCommand = `npx ${command}`;
-
-  debug(npxCommand);
-
-  let ps = exec(npxCommand, {
+  let ps = exec(`npx ${command}`, {
     preferLocal: true,
     stdio: ['pipe', 'pipe', 'inherit'],
     ...options


### PR DESCRIPTION
The `exec` util already does this.